### PR TITLE
Extend VM features

### DIFF
--- a/runtime/tests/vm.rs
+++ b/runtime/tests/vm.rs
@@ -1,0 +1,57 @@
+use runtime::{Instruction, Vm, VmError};
+
+#[test]
+fn addition_works() {
+    let mut vm = Vm::new();
+    let prog = [Instruction::Push(2), Instruction::Push(3), Instruction::Add];
+    let result = vm.execute(&prog).unwrap();
+    assert_eq!(result, 5);
+}
+
+#[test]
+fn multiplication_works() {
+    let mut vm = Vm::new();
+    let prog = [Instruction::Push(4), Instruction::Push(6), Instruction::Mul];
+    assert_eq!(vm.execute(&prog).unwrap(), 24);
+}
+
+#[test]
+fn division_by_zero_fails() {
+    let mut vm = Vm::new();
+    let prog = [Instruction::Push(1), Instruction::Push(0), Instruction::Div];
+    assert_eq!(vm.execute(&prog).unwrap_err(), VmError::DivisionByZero);
+}
+
+#[test]
+fn stack_underflow_detected() {
+    let mut vm = Vm::new();
+    let prog = [Instruction::Add];
+    assert_eq!(vm.execute(&prog).unwrap_err(), VmError::StackUnderflow);
+}
+
+#[test]
+fn dup_and_swap_work() {
+    let mut vm = Vm::new();
+    let prog = [
+        Instruction::Push(1),
+        Instruction::Dup,
+        Instruction::Push(2),
+        Instruction::Swap,
+        Instruction::Add,
+        Instruction::Add,
+    ];
+    assert_eq!(vm.execute(&prog).unwrap(), 4);
+}
+
+#[test]
+fn store_and_load_work() {
+    let mut vm = Vm::new();
+    let prog = [
+        Instruction::Push(42),
+        Instruction::Store(0),
+        Instruction::Load(0),
+        Instruction::Push(8),
+        Instruction::Add,
+    ];
+    assert_eq!(vm.execute(&prog).unwrap(), 50);
+}


### PR DESCRIPTION
## Summary
- expand VM instruction set with duplication, swapping, and memory operations
- move VM tests to a dedicated module

## Testing
- `cargo clippy --manifest-path runtime/Cargo.toml -- -D warnings`
- `cargo clippy --manifest-path jobmanager/Cargo.toml -- -D warnings`
- `cargo test --manifest-path runtime/Cargo.toml`
- `cargo test --manifest-path jobmanager/Cargo.toml`


------
https://chatgpt.com/codex/tasks/task_e_684af1db89b8832fb5fbaf75e66a7ff3