### PR TITLE
Implement token ledger with staking

### DIFF
--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -1,5 +1,7 @@
 use thiserror::Error;
 
+pub mod token;
+
 /// Errors that can occur during VM execution.
 #[derive(Debug, Error, PartialEq, Eq)]
 pub enum VmError {

--- a/runtime/src/token.rs
+++ b/runtime/src/token.rs
@@ -1,0 +1,81 @@
+use std::collections::HashMap;
+use thiserror::Error;
+
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum LedgerError {
+    #[error("insufficient balance")]
+    InsufficientBalance,
+    #[error("insufficient stake")]
+    InsufficientStake,
+}
+
+/// Simple in-memory ledger for balances and staking.
+pub struct TokenLedger {
+    balances: HashMap<String, u64>,
+    stakes: HashMap<String, u64>,
+}
+
+impl Default for TokenLedger {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl TokenLedger {
+    /// Create a new empty ledger.
+    pub fn new() -> Self {
+        Self { balances: HashMap::new(), stakes: HashMap::new() }
+    }
+
+    /// Return the free token balance for `account`.
+    pub fn balance(&self, account: &str) -> u64 {
+        *self.balances.get(account).unwrap_or(&0)
+    }
+
+    /// Return the staked token balance for `account`.
+    pub fn staked(&self, account: &str) -> u64 {
+        *self.stakes.get(account).unwrap_or(&0)
+    }
+
+    /// Mint new tokens into `account`.
+    pub fn mint(&mut self, account: &str, amount: u64) {
+        let entry = self.balances.entry(account.to_string()).or_default();
+        *entry += amount;
+    }
+
+    /// Transfer tokens between accounts.
+    pub fn transfer(&mut self, from: &str, to: &str, amount: u64) -> Result<(), LedgerError> {
+        let from_bal = self.balances.entry(from.to_string()).or_default();
+        if *from_bal < amount {
+            return Err(LedgerError::InsufficientBalance);
+        }
+        *from_bal -= amount;
+        let to_bal = self.balances.entry(to.to_string()).or_default();
+        *to_bal += amount;
+        Ok(())
+    }
+
+    /// Stake tokens from the caller's balance.
+    pub fn stake(&mut self, account: &str, amount: u64) -> Result<(), LedgerError> {
+        let bal = self.balances.entry(account.to_string()).or_default();
+        if *bal < amount {
+            return Err(LedgerError::InsufficientBalance);
+        }
+        *bal -= amount;
+        let st = self.stakes.entry(account.to_string()).or_default();
+        *st += amount;
+        Ok(())
+    }
+
+    /// Unstake tokens back to the caller's balance.
+    pub fn unstake(&mut self, account: &str, amount: u64) -> Result<(), LedgerError> {
+        let st = self.stakes.entry(account.to_string()).or_default();
+        if *st < amount {
+            return Err(LedgerError::InsufficientStake);
+        }
+        *st -= amount;
+        let bal = self.balances.entry(account.to_string()).or_default();
+        *bal += amount;
+        Ok(())
+    }
+}

--- a/runtime/tests/token.rs
+++ b/runtime/tests/token.rs
@@ -1,0 +1,32 @@
+use runtime::token::{LedgerError, TokenLedger};
+
+#[test]
+fn mint_and_transfer() {
+    let mut ledger = TokenLedger::new();
+    ledger.mint("alice", 100);
+    assert_eq!(ledger.balance("alice"), 100);
+    ledger.transfer("alice", "bob", 40).unwrap();
+    assert_eq!(ledger.balance("alice"), 60);
+    assert_eq!(ledger.balance("bob"), 40);
+}
+
+#[test]
+fn stake_and_unstake() {
+    let mut ledger = TokenLedger::new();
+    ledger.mint("alice", 50);
+    ledger.stake("alice", 30).unwrap();
+    assert_eq!(ledger.balance("alice"), 20);
+    assert_eq!(ledger.staked("alice"), 30);
+    ledger.unstake("alice", 10).unwrap();
+    assert_eq!(ledger.balance("alice"), 30);
+    assert_eq!(ledger.staked("alice"), 20);
+}
+
+#[test]
+fn staking_errors() {
+    let mut ledger = TokenLedger::new();
+    ledger.mint("alice", 10);
+    assert_eq!(ledger.stake("alice", 20).unwrap_err(), LedgerError::InsufficientBalance);
+    ledger.stake("alice", 10).unwrap();
+    assert_eq!(ledger.unstake("alice", 20).unwrap_err(), LedgerError::InsufficientStake);
+}


### PR DESCRIPTION
## Summary
- add simple token ledger with staking to runtime
- expose the ledger in runtime lib
- test basic mint, transfer, and staking flows

## Testing
- `cargo clippy -- -D warnings` in runtime
- `cargo test` in runtime
- `cargo test` in jobmanager

------
https://chatgpt.com/codex/tasks/task_e_684af4586118832f94809c4e9c680ae8