### PR TITLE
Add CI workflow for lint and tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,27 @@
+name: CI
+
+on:
+  push:
+    branches: ["*"]
+  pull_request:
+    branches: ["*"]
+
+jobs:
+  lint-test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        crate: [jobmanager, runtime]
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+          components: rustfmt, clippy
+      - name: Rust format check
+        run: cargo fmt --manifest-path ${{ matrix.crate }}/Cargo.toml -- --check
+      - name: Clippy
+        run: cargo clippy --manifest-path ${{ matrix.crate }}/Cargo.toml -- -D warnings
+      - name: Tests
+        run: cargo test --manifest-path ${{ matrix.crate }}/Cargo.toml


### PR DESCRIPTION
## Summary
- set up GitHub Actions workflow to run `cargo fmt`, `clippy`, and tests for each crate

## Testing
- `cargo clippy --manifest-path jobmanager/Cargo.toml -- -D warnings`
- `cargo clippy --manifest-path runtime/Cargo.toml -- -D warnings`
- `cargo test --manifest-path jobmanager/Cargo.toml`
- `cargo test --manifest-path runtime/Cargo.toml`


------
https://chatgpt.com/codex/tasks/task_e_684b1d1037e4832fb0a1792f6c026b33