### PR TITLE
Implement trainer and evaluator roles

### DIFF
--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -12,7 +12,7 @@ This document breaks down roadmap milestones into actionable tasks for early dev
 
 ## Milestone 3: Testnet Alpha (Q2 2026)
 - [x] Implement a simple Proof-of-Useful-Work consensus algorithm (see `runtime/src/pouw.rs`)
-- [ ] Develop trainer and evaluator node roles
+- [x] Develop trainer and evaluator node roles
 - [ ] Add basic P2P networking between nodes
 - [ ] Deploy early runtime modules on the devnet
 - [ ] Launch an internal dashboard/explorer for jobs

--- a/runtime/src/evaluator.rs
+++ b/runtime/src/evaluator.rs
@@ -1,0 +1,19 @@
+use crate::pouw::{Solution, Task, verify};
+
+/// Evaluator node responsible for verifying PoUW solutions.
+#[derive(Debug, Clone)]
+pub struct Evaluator {
+    pub name: String,
+}
+
+impl Evaluator {
+    /// Create a new evaluator with the given name.
+    pub fn new(name: impl Into<String>) -> Self {
+        Self { name: name.into() }
+    }
+
+    /// Verify a trainer's solution for the given task and difficulty.
+    pub fn evaluate(&self, task: &Task, solution: &Solution, difficulty: u32) -> bool {
+        verify(task, solution, difficulty)
+    }
+}

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -1,9 +1,11 @@
 use thiserror::Error;
 
+pub mod evaluator;
 pub mod gpu;
 pub mod job_manager;
 pub mod pouw;
 pub mod token;
+pub mod trainer;
 
 /// Errors that can occur during VM execution.
 #[derive(Debug, Error, PartialEq, Eq)]

--- a/runtime/src/trainer.rs
+++ b/runtime/src/trainer.rs
@@ -1,0 +1,19 @@
+use crate::pouw::{Solution, Task, solve};
+
+/// Simple trainer node capable of solving Proof-of-Useful-Work tasks.
+#[derive(Debug, Clone)]
+pub struct Trainer {
+    pub name: String,
+}
+
+impl Trainer {
+    /// Create a new trainer with the given name.
+    pub fn new(name: impl Into<String>) -> Self {
+        Self { name: name.into() }
+    }
+
+    /// Solve the provided PoUW task at the given difficulty.
+    pub fn train(&self, task: &Task, difficulty: u32) -> Solution {
+        solve(task, difficulty)
+    }
+}

--- a/runtime/tests/trainer_evaluator.rs
+++ b/runtime/tests/trainer_evaluator.rs
@@ -1,0 +1,12 @@
+use runtime::evaluator::Evaluator;
+use runtime::pouw::generate_task;
+use runtime::trainer::Trainer;
+
+#[test]
+fn trainer_and_evaluator_flow() {
+    let task = generate_task(2, 1);
+    let trainer = Trainer::new("alice");
+    let solution = trainer.train(&task, 0x0000ffff);
+    let evaluator = Evaluator::new("bob");
+    assert!(evaluator.evaluate(&task, &solution, 0x0000ffff));
+}


### PR DESCRIPTION
## Summary
- add `trainer` and `evaluator` modules to runtime
- expose the new modules in `runtime` crate
- mark the trainer/evaluator milestone as complete
- test trainer and evaluator interaction

## Testing
- `cargo test --manifest-path runtime/Cargo.toml`


------
https://chatgpt.com/codex/tasks/task_e_684bbb50dca0832fbec6a47f1e380fca