### PR TITLE
Integrate job manager into devnet CLI

### DIFF
--- a/devnet/src/lib.rs
+++ b/devnet/src/lib.rs
@@ -1,3 +1,4 @@
+use runtime::job_manager::{Job, JobManagerError};
 use runtime::token::{LedgerError, TokenLedger};
 use serde::{Deserialize, Serialize};
 use std::fs;
@@ -15,7 +16,13 @@ struct LedgerWrapper {
     ledger: TokenLedger,
 }
 
+#[derive(Debug, Serialize, Deserialize)]
+struct JobsWrapper {
+    jobs: Vec<Job>,
+}
+
 pub const LEDGER_FILE: &str = "ledger.json";
+pub const JOBS_FILE: &str = "jobs.json";
 
 pub fn load_ledger() -> Result<TokenLedger, DevnetError> {
     if !std::path::Path::new(LEDGER_FILE).exists() {
@@ -29,6 +36,21 @@ pub fn load_ledger() -> Result<TokenLedger, DevnetError> {
 pub fn save_ledger(ledger: &TokenLedger) -> Result<(), DevnetError> {
     let data = serde_json::to_string_pretty(&LedgerWrapper { ledger: ledger.clone() })?;
     fs::write(LEDGER_FILE, data)?;
+    Ok(())
+}
+
+pub fn load_jobs() -> Result<Vec<Job>, DevnetError> {
+    if !std::path::Path::new(JOBS_FILE).exists() {
+        return Ok(Vec::new());
+    }
+    let data = fs::read_to_string(JOBS_FILE)?;
+    let wrapper: JobsWrapper = serde_json::from_str(&data)?;
+    Ok(wrapper.jobs)
+}
+
+pub fn save_jobs(jobs: &[Job]) -> Result<(), DevnetError> {
+    let data = serde_json::to_string_pretty(&JobsWrapper { jobs: jobs.to_vec() })?;
+    fs::write(JOBS_FILE, data)?;
     Ok(())
 }
 
@@ -51,4 +73,59 @@ pub fn stake(ledger: &mut TokenLedger, account: &str, amount: u64) -> Result<(),
 
 pub fn unstake(ledger: &mut TokenLedger, account: &str, amount: u64) -> Result<(), LedgerError> {
     ledger.unstake(account, amount)
+}
+
+pub fn train_and_verify(size: usize, seed: u64, difficulty: u32) -> bool {
+    use runtime::evaluator::Evaluator;
+    use runtime::pouw::generate_task;
+    use runtime::trainer::Trainer;
+
+    let task = generate_task(size, seed);
+    let trainer = Trainer::new("trainer");
+    let solution = trainer.train(&task, difficulty);
+    let evaluator = Evaluator::new("evaluator");
+    evaluator.evaluate(&task, &solution, difficulty)
+}
+
+pub fn post_job(
+    jobs: &mut Vec<Job>,
+    ledger: &mut TokenLedger,
+    poster: &str,
+    description: String,
+    reward: u64,
+) -> Result<(), JobManagerError> {
+    if ledger.balance(poster) < reward {
+        return Err(JobManagerError::InsufficientBalance);
+    }
+    ledger.transfer(poster, "escrow", reward).unwrap();
+    let id = jobs.last().map(|j| j.id + 1).unwrap_or(1);
+    jobs.push(Job { id, description, reward, assigned_to: None, completed: false });
+    Ok(())
+}
+
+pub fn assign_job(jobs: &mut [Job], job_id: u64, worker: &str) -> Result<(), JobManagerError> {
+    let job = jobs.iter_mut().find(|j| j.id == job_id).ok_or(JobManagerError::JobNotFound)?;
+    if job.completed {
+        return Err(JobManagerError::AlreadyCompleted);
+    }
+    if job.assigned_to.is_some() {
+        return Err(JobManagerError::AlreadyAssigned);
+    }
+    job.assigned_to = Some(worker.to_string());
+    Ok(())
+}
+
+pub fn complete_job(
+    jobs: &mut [Job],
+    ledger: &mut TokenLedger,
+    job_id: u64,
+) -> Result<(), JobManagerError> {
+    let job = jobs.iter_mut().find(|j| j.id == job_id).ok_or(JobManagerError::JobNotFound)?;
+    if job.completed {
+        return Err(JobManagerError::AlreadyCompleted);
+    }
+    let worker = job.assigned_to.clone().ok_or(JobManagerError::AlreadyAssigned)?;
+    job.completed = true;
+    ledger.transfer("escrow", &worker, job.reward).unwrap();
+    Ok(())
 }

--- a/devnet/tests/basic.rs
+++ b/devnet/tests/basic.rs
@@ -13,3 +13,20 @@ fn mint_and_stake_flow() {
     assert_eq!(ledger.balance("alice"), 70);
     assert_eq!(ledger.staked("alice"), 30);
 }
+
+#[test]
+fn train_and_verify_flow() {
+    assert!(train_and_verify(2, 1, 0x0000ffff));
+}
+
+#[test]
+fn job_flow() {
+    let mut ledger = TokenLedger::new();
+    mint(&mut ledger, "alice", 100);
+    let mut jobs = Vec::new();
+    post_job(&mut jobs, &mut ledger, "alice", "task".into(), 50).unwrap();
+    assert_eq!(ledger.balance("alice"), 50);
+    assign_job(&mut jobs, 1, "bob").unwrap();
+    complete_job(&mut jobs, &mut ledger, 1).unwrap();
+    assert_eq!(ledger.balance("bob"), 50);
+}

--- a/runtime/src/job_manager.rs
+++ b/runtime/src/job_manager.rs
@@ -1,8 +1,9 @@
+use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 use crate::token::TokenLedger;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Job {
     pub id: u64,
     pub description: String,


### PR DESCRIPTION
## Summary
- persist jobs to `jobs.json`
- allow posting, assigning and completing jobs via devnet CLI
- expose job management helpers in library
- cover job flow with unit test

## Testing
- `cargo clippy --manifest-path runtime/Cargo.toml -- -D warnings`
- `cargo clippy --manifest-path devnet/Cargo.toml -- -D warnings`
- `cargo test --manifest-path runtime/Cargo.toml`
- `cargo test --manifest-path devnet/Cargo.toml`


------
https://chatgpt.com/codex/tasks/task_e_684bc6992b64832fb900f7565c6697e7