### PR TITLE
Implement slashing and reputation

### DIFF
--- a/devnet/src/lib.rs
+++ b/devnet/src/lib.rs
@@ -23,6 +23,7 @@ struct JobsWrapper {
 
 pub const LEDGER_FILE: &str = "ledger.json";
 pub const JOBS_FILE: &str = "jobs.json";
+pub const TREASURY: &str = "treasury";
 
 pub fn load_ledger() -> Result<TokenLedger, DevnetError> {
     if !std::path::Path::new(LEDGER_FILE).exists() {
@@ -73,6 +74,18 @@ pub fn stake(ledger: &mut TokenLedger, account: &str, amount: u64) -> Result<(),
 
 pub fn unstake(ledger: &mut TokenLedger, account: &str, amount: u64) -> Result<(), LedgerError> {
     ledger.unstake(account, amount)
+}
+
+pub fn slash(ledger: &mut TokenLedger, offender: &str, amount: u64) -> Result<(), LedgerError> {
+    ledger.slash(offender, TREASURY, amount)
+}
+
+pub fn reputation(ledger: &TokenLedger, account: &str) -> i32 {
+    ledger.reputation(account)
+}
+
+pub fn adjust_reputation(ledger: &mut TokenLedger, account: &str, delta: i32) {
+    ledger.adjust_reputation(account, delta);
 }
 
 pub fn train_and_verify(size: usize, seed: u64, difficulty: u32) -> bool {

--- a/devnet/src/main.rs
+++ b/devnet/src/main.rs
@@ -23,8 +23,14 @@ enum Commands {
     Stake { account: String, amount: u64 },
     /// Unstake tokens
     Unstake { account: String, amount: u64 },
+    /// Slash staked tokens to the treasury
+    Slash { account: String, amount: u64 },
     /// Show balances
     Balance { account: String },
+    /// Show reputation score
+    Reputation { account: String },
+    /// Adjust reputation by delta
+    AdjustRep { account: String, delta: i32 },
     /// Mine a block executing a dummy GPU task
     Mine,
     /// Run a PoUW training task
@@ -83,12 +89,23 @@ fn main() -> Result<(), DevnetError> {
                         println!("{e}");
                     }
                 }
+                Commands::Slash { account, amount } => {
+                    if let Err(e) = slash(&mut ledger, &account, amount) {
+                        println!("{e}");
+                    }
+                }
                 Commands::Balance { account } => {
                     println!(
                         "balance: {} staked: {}",
                         ledger.balance(&account),
                         ledger.staked(&account)
                     );
+                }
+                Commands::Reputation { account } => {
+                    println!("reputation: {}", reputation(&ledger, &account));
+                }
+                Commands::AdjustRep { account, delta } => {
+                    adjust_reputation(&mut ledger, &account, delta);
                 }
                 Commands::Mine => {
                     let input = vec![1.0f32, 2.0, 3.0, 4.0];

--- a/devnet/tests/basic.rs
+++ b/devnet/tests/basic.rs
@@ -30,3 +30,15 @@ fn job_flow() {
     complete_job(&mut jobs, &mut ledger, 1).unwrap();
     assert_eq!(ledger.balance("bob"), 50);
 }
+
+#[test]
+fn slash_and_reputation_flow() {
+    let mut ledger = TokenLedger::new();
+    mint(&mut ledger, "off", 100);
+    stake(&mut ledger, "off", 40).unwrap();
+    adjust_reputation(&mut ledger, "off", 3);
+    assert_eq!(reputation(&ledger, "off"), 3);
+    slash(&mut ledger, "off", 25).unwrap();
+    assert_eq!(ledger.staked("off"), 15);
+    assert_eq!(ledger.balance(TREASURY), 25);
+}

--- a/runtime/tests/token.rs
+++ b/runtime/tests/token.rs
@@ -30,3 +30,18 @@ fn staking_errors() {
     ledger.stake("alice", 10).unwrap();
     assert_eq!(ledger.unstake("alice", 20).unwrap_err(), LedgerError::InsufficientStake);
 }
+
+#[test]
+fn slashing_and_reputation() {
+    let mut ledger = TokenLedger::new();
+    ledger.mint("offender", 50);
+    ledger.stake("offender", 30).unwrap();
+    assert_eq!(ledger.staked("offender"), 30);
+    ledger.adjust_reputation("offender", 5);
+    assert_eq!(ledger.reputation("offender"), 5);
+    ledger.slash("offender", "treasury", 20).unwrap();
+    assert_eq!(ledger.staked("offender"), 10);
+    assert_eq!(ledger.balance("treasury"), 20);
+    ledger.adjust_reputation("offender", -3);
+    assert_eq!(ledger.reputation("offender"), 2);
+}


### PR DESCRIPTION
## Summary
- add slashing and reputation tracking to `TokenLedger`
- expose slashing and reputation helpers in devnet library and CLI
- test new functionality in runtime and devnet crates

## Testing
- `cargo clippy -- -D warnings` for runtime, devnet, jobmanager, p2p, dashboard
- `cargo test --quiet` for runtime, devnet, jobmanager, p2p, dashboard

------
https://chatgpt.com/codex/tasks/task_e_684c025ee8c8832fbaf0d0fd0cb6771a