### PR TITLE
Expand error handling in core crates

### DIFF
--- a/dashboard/src/lib.rs
+++ b/dashboard/src/lib.rs
@@ -24,9 +24,9 @@ pub fn serve(addr: &str) -> Result<(), Box<dyn std::error::Error + Send + Sync>>
             "/jobs" => {
                 let jobs = load_jobs()?;
                 let html = render_jobs(&jobs);
-                let response = Response::from_string(html).with_header(
-                    tiny_http::Header::from_bytes(b"Content-Type", b"text/html").unwrap(),
-                );
+                let header = tiny_http::Header::from_bytes(b"Content-Type", b"text/html")
+                    .expect("valid header bytes");
+                let response = Response::from_string(html).with_header(header);
                 request.respond(response)?;
             }
             _ => {

--- a/devnet/src/lib.rs
+++ b/devnet/src/lib.rs
@@ -110,7 +110,7 @@ pub fn post_job(
     if ledger.balance(poster) < reward {
         return Err(JobManagerError::InsufficientBalance);
     }
-    ledger.transfer(poster, "escrow", reward).unwrap();
+    ledger.transfer(poster, "escrow", reward)?;
     let id = jobs.last().map(|j| j.id + 1).unwrap_or(1);
     jobs.push(Job { id, description, reward, assigned_to: None, completed: false });
     Ok(())
@@ -139,6 +139,6 @@ pub fn complete_job(
     }
     let worker = job.assigned_to.clone().ok_or(JobManagerError::AlreadyAssigned)?;
     job.completed = true;
-    ledger.transfer("escrow", &worker, job.reward).unwrap();
+    ledger.transfer("escrow", &worker, job.reward)?;
     Ok(())
 }

--- a/devnet/src/main.rs
+++ b/devnet/src/main.rs
@@ -132,7 +132,11 @@ fn main() -> Result<(), DevnetError> {
                     match job {
                         JobCommands::Post { poster, description, reward } => {
                             match post_job(&mut jobs, &mut ledger, &poster, description, reward) {
-                                Ok(()) => println!("posted job #{}", jobs.last().unwrap().id),
+                                Ok(()) => {
+                                    if let Some(j) = jobs.last() {
+                                        println!("posted job #{}", j.id);
+                                    }
+                                }
                                 Err(e) => println!("{e}"),
                             }
                         }

--- a/devnet/tests/basic.rs
+++ b/devnet/tests/basic.rs
@@ -2,16 +2,17 @@ use devnet::*;
 use runtime::token::TokenLedger;
 
 #[test]
-fn mint_and_stake_flow() {
+fn mint_and_stake_flow() -> Result<(), runtime::token::LedgerError> {
     let mut ledger = TokenLedger::new();
     mint(&mut ledger, "alice", 100);
     assert_eq!(ledger.balance("alice"), 100);
-    stake(&mut ledger, "alice", 40).unwrap();
+    stake(&mut ledger, "alice", 40)?;
     assert_eq!(ledger.balance("alice"), 60);
     assert_eq!(ledger.staked("alice"), 40);
-    unstake(&mut ledger, "alice", 10).unwrap();
+    unstake(&mut ledger, "alice", 10)?;
     assert_eq!(ledger.balance("alice"), 70);
     assert_eq!(ledger.staked("alice"), 30);
+    Ok(())
 }
 
 #[test]
@@ -20,25 +21,27 @@ fn train_and_verify_flow() {
 }
 
 #[test]
-fn job_flow() {
+fn job_flow() -> Result<(), runtime::job_manager::JobManagerError> {
     let mut ledger = TokenLedger::new();
     mint(&mut ledger, "alice", 100);
     let mut jobs = Vec::new();
-    post_job(&mut jobs, &mut ledger, "alice", "task".into(), 50).unwrap();
+    post_job(&mut jobs, &mut ledger, "alice", "task".into(), 50)?;
     assert_eq!(ledger.balance("alice"), 50);
-    assign_job(&mut jobs, 1, "bob").unwrap();
-    complete_job(&mut jobs, &mut ledger, 1).unwrap();
+    assign_job(&mut jobs, 1, "bob")?;
+    complete_job(&mut jobs, &mut ledger, 1)?;
     assert_eq!(ledger.balance("bob"), 50);
+    Ok(())
 }
 
 #[test]
-fn slash_and_reputation_flow() {
+fn slash_and_reputation_flow() -> Result<(), runtime::token::LedgerError> {
     let mut ledger = TokenLedger::new();
     mint(&mut ledger, "off", 100);
-    stake(&mut ledger, "off", 40).unwrap();
+    stake(&mut ledger, "off", 40)?;
     adjust_reputation(&mut ledger, "off", 3);
     assert_eq!(reputation(&ledger, "off"), 3);
-    slash(&mut ledger, "off", 25).unwrap();
+    slash(&mut ledger, "off", 25)?;
     assert_eq!(ledger.staked("off"), 15);
     assert_eq!(ledger.balance(TREASURY), 25);
+    Ok(())
 }

--- a/jobmanager/examples/job_cycle.rs
+++ b/jobmanager/examples/job_cycle.rs
@@ -1,0 +1,11 @@
+use jobmanager_lib::{load_jobs, save_jobs, post_job, assign_job, complete_job};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut jobs = load_jobs()?;
+    let job = post_job(&mut jobs, "demo job".into(), 10);
+    assign_job(jobs.as_mut_slice(), job.id, "worker1".into())?;
+    complete_job(jobs.as_mut_slice(), job.id)?;
+    save_jobs(&jobs)?;
+    println!("Job {} completed", job.id);
+    Ok(())
+}

--- a/jobmanager/examples/job_cycle.rs
+++ b/jobmanager/examples/job_cycle.rs
@@ -1,4 +1,4 @@
-use jobmanager_lib::{load_jobs, save_jobs, post_job, assign_job, complete_job};
+use jobmanager_lib::{assign_job, complete_job, load_jobs, post_job, save_jobs};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut jobs = load_jobs()?;

--- a/jobmanager/src/lib.rs
+++ b/jobmanager/src/lib.rs
@@ -18,6 +18,8 @@ pub enum JobError {
     Io(#[from] std::io::Error),
     #[error("Serialization error: {0}")]
     Serde(#[from] serde_json::Error),
+    #[error("job not found")]
+    JobNotFound,
 }
 
 pub const DATA_FILE: &str = "jobs.json";
@@ -44,20 +46,20 @@ pub fn post_job(jobs: &mut Vec<Job>, description: String, reward: u64) -> Job {
     job
 }
 
-pub fn assign_job(jobs: &mut [Job], job_id: u64, worker: String) -> Option<()> {
+pub fn assign_job(jobs: &mut [Job], job_id: u64, worker: String) -> Result<(), JobError> {
     if let Some(job) = jobs.iter_mut().find(|j| j.id == job_id) {
         job.assigned_to = Some(worker);
-        return Some(());
+        return Ok(());
     }
-    None
+    Err(JobError::JobNotFound)
 }
 
-pub fn complete_job(jobs: &mut [Job], job_id: u64) -> Option<()> {
+pub fn complete_job(jobs: &mut [Job], job_id: u64) -> Result<(), JobError> {
     if let Some(job) = jobs.iter_mut().find(|j| j.id == job_id) {
         job.completed = true;
-        return Some(());
+        return Ok(());
     }
-    None
+    Err(JobError::JobNotFound)
 }
 
 #[cfg(test)]
@@ -69,16 +71,17 @@ mod tests {
     }
 
     #[test]
-    fn post_assign_complete_cycle() {
+    fn post_assign_complete_cycle() -> Result<(), JobError> {
         setup();
-        let mut jobs = load_jobs().unwrap();
+        let mut jobs = load_jobs()?;
         let job = post_job(&mut jobs, "a task".into(), 50);
         assert_eq!(job.id, 1);
-        assign_job(jobs.as_mut_slice(), job.id, "worker1".into()).unwrap();
-        complete_job(jobs.as_mut_slice(), job.id).unwrap();
-        save_jobs(&jobs).unwrap();
-        let loaded = load_jobs().unwrap();
+        assign_job(jobs.as_mut_slice(), job.id, "worker1".into())?;
+        complete_job(jobs.as_mut_slice(), job.id)?;
+        save_jobs(&jobs)?;
+        let loaded = load_jobs()?;
         assert!(loaded[0].completed);
         assert_eq!(loaded[0].assigned_to.as_deref(), Some("worker1"));
+        Ok(())
     }
 }

--- a/jobmanager/src/main.rs
+++ b/jobmanager/src/main.rs
@@ -44,22 +44,22 @@ fn main() -> Result<(), JobError> {
             save_jobs(&jobs)?;
             println!("Posted job #{}", job.id);
         }
-        Commands::Assign { job_id, worker } => {
-            if assign_job(&mut jobs, job_id, worker).is_some() {
+        Commands::Assign { job_id, worker } => match assign_job(&mut jobs, job_id, worker) {
+            Ok(_) => {
                 save_jobs(&jobs)?;
                 println!("Assigned job #{job_id}");
-            } else {
-                println!("Job #{job_id} not found");
             }
-        }
-        Commands::Complete { job_id } => {
-            if complete_job(&mut jobs, job_id).is_some() {
+            Err(JobError::JobNotFound) => println!("Job #{job_id} not found"),
+            Err(e) => return Err(e),
+        },
+        Commands::Complete { job_id } => match complete_job(&mut jobs, job_id) {
+            Ok(_) => {
                 save_jobs(&jobs)?;
                 println!("Completed job #{job_id}");
-            } else {
-                println!("Job #{job_id} not found");
             }
-        }
+            Err(JobError::JobNotFound) => println!("Job #{job_id} not found"),
+            Err(e) => return Err(e),
+        },
         Commands::List => {
             for job in &jobs {
                 println!(

--- a/jobmanager/tests/integration.rs
+++ b/jobmanager/tests/integration.rs
@@ -8,7 +8,11 @@ fn setup() {
 #[test]
 fn post_and_list() {
     setup();
-    Command::cargo_bin("jobmanager").expect("binary").args(["post", "test job", "100"]).assert().success();
+    Command::cargo_bin("jobmanager")
+        .expect("binary")
+        .args(["post", "test job", "100"])
+        .assert()
+        .success();
 
     let assert = Command::cargo_bin("jobmanager").expect("binary").arg("list").assert().success();
     let output = String::from_utf8(assert.get_output().stdout.clone()).expect("utf8");

--- a/jobmanager/tests/integration.rs
+++ b/jobmanager/tests/integration.rs
@@ -8,9 +8,9 @@ fn setup() {
 #[test]
 fn post_and_list() {
     setup();
-    Command::cargo_bin("jobmanager").unwrap().args(["post", "test job", "100"]).assert().success();
+    Command::cargo_bin("jobmanager").expect("binary").args(["post", "test job", "100"]).assert().success();
 
-    let assert = Command::cargo_bin("jobmanager").unwrap().arg("list").assert().success();
-    let output = String::from_utf8(assert.get_output().stdout.clone()).unwrap();
+    let assert = Command::cargo_bin("jobmanager").expect("binary").arg("list").assert().success();
+    let output = String::from_utf8(assert.get_output().stdout.clone()).expect("utf8");
     assert!(output.contains("test job"));
 }

--- a/p2p/src/lib.rs
+++ b/p2p/src/lib.rs
@@ -70,7 +70,8 @@ impl Codec for JobCodec {
     where
         T: futures::AsyncWrite + Unpin + Send,
     {
-        let bytes = bincode::serialize(&req).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+        let bytes =
+            bincode::serialize(&req).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
         futures::io::AsyncWriteExt::write_all(io, &bytes).await?;
         futures::io::AsyncWriteExt::close(io).await
     }
@@ -84,7 +85,8 @@ impl Codec for JobCodec {
     where
         T: futures::AsyncWrite + Unpin + Send,
     {
-        let bytes = bincode::serialize(&res).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+        let bytes =
+            bincode::serialize(&res).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
         futures::io::AsyncWriteExt::write_all(io, &bytes).await?;
         futures::io::AsyncWriteExt::close(io).await
     }

--- a/p2p/src/lib.rs
+++ b/p2p/src/lib.rs
@@ -70,7 +70,7 @@ impl Codec for JobCodec {
     where
         T: futures::AsyncWrite + Unpin + Send,
     {
-        let bytes = bincode::serialize(&req).unwrap();
+        let bytes = bincode::serialize(&req).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
         futures::io::AsyncWriteExt::write_all(io, &bytes).await?;
         futures::io::AsyncWriteExt::close(io).await
     }
@@ -84,7 +84,7 @@ impl Codec for JobCodec {
     where
         T: futures::AsyncWrite + Unpin + Send,
     {
-        let bytes = bincode::serialize(&res).unwrap();
+        let bytes = bincode::serialize(&res).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
         futures::io::AsyncWriteExt::write_all(io, &bytes).await?;
         futures::io::AsyncWriteExt::close(io).await
     }
@@ -149,13 +149,13 @@ impl Node {
 
     pub fn listen(&mut self) -> Multiaddr {
         let port: u64 = rand::thread_rng().gen_range(1..u64::MAX);
-        let addr: Multiaddr = format!("/memory/{port}").parse().unwrap();
-        self.swarm.listen_on(addr.clone()).unwrap();
+        let addr: Multiaddr = format!("/memory/{port}").parse().expect("memory addr");
+        self.swarm.listen_on(addr.clone()).expect("listen_on");
         addr
     }
 
     pub fn dial(&mut self, addr: Multiaddr) {
-        self.swarm.dial(addr).unwrap();
+        self.swarm.dial(addr).expect("dial");
     }
 
     pub fn send_handshake(&mut self, peer: PeerId) {
@@ -213,7 +213,7 @@ impl Node {
                                                 .behaviour_mut()
                                                 .req
                                                 .send_response(channel, resp)
-                                                .unwrap();
+                                                .expect("send handshake response");
                                             continue;
                                         }
                                         JobRequest::Train(data) => {
@@ -223,7 +223,7 @@ impl Node {
                                                 .behaviour_mut()
                                                 .req
                                                 .send_response(channel, resp)
-                                                .unwrap();
+                                                .expect("send train response");
                                             continue;
                                         }
                                     }

--- a/p2p/tests/linear.rs
+++ b/p2p/tests/linear.rs
@@ -32,7 +32,7 @@ fn local_train(data: &[u8]) -> Vec<f32> {
 
 #[tokio::test]
 async fn distributed_linear_regression() {
-    let data = std::fs::read("tests/data/linear.csv").unwrap();
+    let data = std::fs::read("tests/data/linear.csv").expect("read dataset");
     let mut a = Node::new(4, 1);
     let mut b = Node::new(8, 2);
     let addr = a.listen();

--- a/runtime/src/gpu.rs
+++ b/runtime/src/gpu.rs
@@ -4,8 +4,8 @@
 //! doubles each input value. While trivial, it shows how to set up WGPU
 //! and run a compute pass.
 
-use wgpu::util::DeviceExt;
 use thiserror::Error;
+use wgpu::util::DeviceExt;
 
 /// Errors that may occur during GPU compute tasks.
 #[derive(Debug, Error)]
@@ -21,12 +21,12 @@ pub enum GpuError {
 pub fn double_numbers(data: &[f32]) -> Result<Vec<f32>, GpuError> {
     // Create a new WGPU instance and choose the first available adapter.
     let instance = wgpu::Instance::default();
-    let adapter = pollster::block_on(
-        instance.request_adapter(&wgpu::RequestAdapterOptions::default()),
-    )
-    .map_err(|e| GpuError::RequestAdapter(format!("{e:?}")))?;
-    let (device, queue) = pollster::block_on(adapter.request_device(&wgpu::DeviceDescriptor::default()))
-        .map_err(|e| GpuError::RequestDevice(e.to_string()))?;
+    let adapter =
+        pollster::block_on(instance.request_adapter(&wgpu::RequestAdapterOptions::default()))
+            .map_err(|e| GpuError::RequestAdapter(format!("{e:?}")))?;
+    let (device, queue) =
+        pollster::block_on(adapter.request_device(&wgpu::DeviceDescriptor::default()))
+            .map_err(|e| GpuError::RequestDevice(e.to_string()))?;
 
     let shader_source = include_str!("double.wgsl");
     let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {

--- a/runtime/tests/job_manager.rs
+++ b/runtime/tests/job_manager.rs
@@ -2,21 +2,22 @@ use runtime::job_manager::{JobManager, JobManagerError};
 use runtime::token::TokenLedger;
 
 #[test]
-fn posting_and_completing_job() {
+fn posting_and_completing_job() -> Result<(), JobManagerError> {
     let mut ledger = TokenLedger::new();
     ledger.mint("alice", 100);
     let mut jm = JobManager::new(ledger);
     // post job
-    jm.post_job("alice", "test".into(), 50).unwrap();
+    jm.post_job("alice", "test".into(), 50)?;
     assert_eq!(jm.jobs().len(), 1);
     assert_eq!(jm.ledger().balance("alice"), 50);
     assert_eq!(jm.ledger().balance("escrow"), 50);
 
     // assign and complete
-    jm.assign_job(1, "bob").unwrap();
-    jm.complete_job(1).unwrap();
+    jm.assign_job(1, "bob")?;
+    jm.complete_job(1)?;
     assert_eq!(jm.ledger().balance("bob"), 50);
     assert_eq!(jm.ledger().balance("escrow"), 0);
+    Ok(())
 }
 
 #[test]

--- a/runtime/tests/token.rs
+++ b/runtime/tests/token.rs
@@ -1,25 +1,27 @@
 use runtime::token::{LedgerError, TokenLedger};
 
 #[test]
-fn mint_and_transfer() {
+fn mint_and_transfer() -> Result<(), LedgerError> {
     let mut ledger = TokenLedger::new();
     ledger.mint("alice", 100);
     assert_eq!(ledger.balance("alice"), 100);
-    ledger.transfer("alice", "bob", 40).unwrap();
+    ledger.transfer("alice", "bob", 40)?;
     assert_eq!(ledger.balance("alice"), 60);
     assert_eq!(ledger.balance("bob"), 40);
+    Ok(())
 }
 
 #[test]
-fn stake_and_unstake() {
+fn stake_and_unstake() -> Result<(), LedgerError> {
     let mut ledger = TokenLedger::new();
     ledger.mint("alice", 50);
-    ledger.stake("alice", 30).unwrap();
+    ledger.stake("alice", 30)?;
     assert_eq!(ledger.balance("alice"), 20);
     assert_eq!(ledger.staked("alice"), 30);
-    ledger.unstake("alice", 10).unwrap();
+    ledger.unstake("alice", 10)?;
     assert_eq!(ledger.balance("alice"), 30);
     assert_eq!(ledger.staked("alice"), 20);
+    Ok(())
 }
 
 #[test]
@@ -27,21 +29,22 @@ fn staking_errors() {
     let mut ledger = TokenLedger::new();
     ledger.mint("alice", 10);
     assert_eq!(ledger.stake("alice", 20).unwrap_err(), LedgerError::InsufficientBalance);
-    ledger.stake("alice", 10).unwrap();
+    ledger.stake("alice", 10).expect("stake succeeds");
     assert_eq!(ledger.unstake("alice", 20).unwrap_err(), LedgerError::InsufficientStake);
 }
 
 #[test]
-fn slashing_and_reputation() {
+fn slashing_and_reputation() -> Result<(), LedgerError> {
     let mut ledger = TokenLedger::new();
     ledger.mint("offender", 50);
-    ledger.stake("offender", 30).unwrap();
+    ledger.stake("offender", 30)?;
     assert_eq!(ledger.staked("offender"), 30);
     ledger.adjust_reputation("offender", 5);
     assert_eq!(ledger.reputation("offender"), 5);
-    ledger.slash("offender", "treasury", 20).unwrap();
+    ledger.slash("offender", "treasury", 20)?;
     assert_eq!(ledger.staked("offender"), 10);
     assert_eq!(ledger.balance("treasury"), 20);
     ledger.adjust_reputation("offender", -3);
     assert_eq!(ledger.reputation("offender"), 2);
+    Ok(())
 }

--- a/runtime/tests/vm.rs
+++ b/runtime/tests/vm.rs
@@ -32,7 +32,7 @@ fn stack_underflow_detected() {
 }
 
 #[test]
-fn dup_and_swap_work() {
+fn dup_and_swap_work() -> Result<(), VmError> {
     let mut vm = Vm::new();
     let prog = [
         Instruction::Push(1),
@@ -42,11 +42,12 @@ fn dup_and_swap_work() {
         Instruction::Add,
         Instruction::Add,
     ];
-    assert_eq!(vm.execute(&prog).unwrap(), 4);
+    assert_eq!(vm.execute(&prog)?, 4);
+    Ok(())
 }
 
 #[test]
-fn store_and_load_work() {
+fn store_and_load_work() -> Result<(), VmError> {
     let mut vm = Vm::new();
     let prog = [
         Instruction::Push(42),
@@ -55,5 +56,6 @@ fn store_and_load_work() {
         Instruction::Push(8),
         Instruction::Add,
     ];
-    assert_eq!(vm.execute(&prog).unwrap(), 50);
+    assert_eq!(vm.execute(&prog)?, 50);
+    Ok(())
 }

--- a/runtime/tests/vm.rs
+++ b/runtime/tests/vm.rs
@@ -1,18 +1,20 @@
 use runtime::{Instruction, Vm, VmError};
 
 #[test]
-fn addition_works() {
+fn addition_works() -> Result<(), VmError> {
     let mut vm = Vm::new();
     let prog = [Instruction::Push(2), Instruction::Push(3), Instruction::Add];
-    let result = vm.execute(&prog).unwrap();
+    let result = vm.execute(&prog)?;
     assert_eq!(result, 5);
+    Ok(())
 }
 
 #[test]
-fn multiplication_works() {
+fn multiplication_works() -> Result<(), VmError> {
     let mut vm = Vm::new();
     let prog = [Instruction::Push(4), Instruction::Push(6), Instruction::Mul];
-    assert_eq!(vm.execute(&prog).unwrap(), 24);
+    assert_eq!(vm.execute(&prog)?, 24);
+    Ok(())
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- define `GpuError` for GPU tasks and return it from `double_numbers`
- propagate ledger errors in `JobManager`
- update `devnet` helpers and CLI to use new error handling
- replace unwraps in `p2p` codec and node
- add example `job_cycle.rs`
- update tests to use `?` instead of `unwrap`

## Testing
- `cargo test --quiet` in `jobmanager`
- `cargo test --quiet` in `runtime`
- `cargo test --quiet` in `devnet`
- `cargo test --quiet` in `p2p`
- `cargo test --quiet` in `dashboard`


------
https://chatgpt.com/codex/tasks/task_e_684c51f99608832fa620186c49a8d4ab