### PR TITLE
Add release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,53 @@
+name: Build Releases
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+            artifact: linux-x86_64
+          - os: macos-14
+            target: aarch64-apple-darwin
+            artifact: macos-aarch64
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          target: ${{ matrix.target }}
+          override: true
+      - name: Build devnet
+        run: cargo build --release --manifest-path devnet/Cargo.toml --target ${{ matrix.target }}
+      - name: Build jobmanager
+        run: cargo build --release --manifest-path jobmanager/Cargo.toml --target ${{ matrix.target }}
+      - name: Package binaries
+        run: |
+          mkdir package
+          cp target/${{ matrix.target }}/release/devnet package/
+          cp target/${{ matrix.target }}/release/jobmanager package/
+          tar -czf ${{ matrix.artifact }}.tar.gz -C package .
+      - uses: actions/upload-artifact@v3
+        with:
+          name: ${{ matrix.artifact }}
+          path: ${{ matrix.artifact }}.tar.gz
+
+  release:
+    if: startsWith(github.ref, 'refs/tags/')
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v3
+        with:
+          path: dist
+      - uses: softprops/action-gh-release@v1
+        with:
+          files: dist/**/*.tar.gz
+

--- a/SETUP.md
+++ b/SETUP.md
@@ -12,6 +12,9 @@ cargo build --release
 ```
 This produces the `jobmanager` binary under `target/release/`.
 
+## Prebuilt Binaries
+Prebuilt archives are produced for Linux x86_64 and Apple Silicon whenever a `v*` tag is pushed. Visit the GitHub Releases page to download `devnet` and `jobmanager` without compiling.
+
 ## Posting a Job
 From the `jobmanager` directory, run:
 ```bash


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to build Linux x86_64 and macOS M1 binaries
- document availability of prebuilt binaries in SETUP guide

## Testing
- `cargo clippy --manifest-path devnet/Cargo.toml -- -D warnings`
- `cargo clippy --manifest-path jobmanager/Cargo.toml -- -D warnings`
- `for crate in devnet jobmanager runtime p2p dashboard; do cargo test --manifest-path $crate/Cargo.toml; done`

------
https://chatgpt.com/codex/tasks/task_e_684c7005c930832f8d2edd3cfb5564cc