### PR TITLE
Implement token burn feature

### DIFF
--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -26,3 +26,10 @@ This document breaks down roadmap milestones into actionable tasks for early dev
  - [x] Hold a community challenge using testnet tokens ([see details](COMMUNITY_CHALLENGE.md))
 
 Additional milestones are outlined in `ROADMAP.md`. This checklist focuses on the near-term steps to bootstrap development and move toward a functional testnet.
+
+## Milestone 5: Audit, Optimization & Hardening (Q4 2026)
+- [ ] Conduct a third-party security audit of the runtime and contracts
+- [x] Implement token burning to allow permanent removal of tokens
+- [x] Expose a `burn` command in the devnet CLI
+- [ ] Profile PoUW execution for bottlenecks and optimize
+- [ ] Stress test job handling with multiple concurrent tasks

--- a/devnet/src/lib.rs
+++ b/devnet/src/lib.rs
@@ -88,6 +88,10 @@ pub fn adjust_reputation(ledger: &mut TokenLedger, account: &str, delta: i32) {
     ledger.adjust_reputation(account, delta);
 }
 
+pub fn burn(ledger: &mut TokenLedger, account: &str, amount: u64) -> Result<(), LedgerError> {
+    ledger.burn(account, amount)
+}
+
 pub fn train_and_verify(size: usize, seed: u64, difficulty: u32) -> bool {
     use runtime::evaluator::Evaluator;
     use runtime::pouw::generate_task;

--- a/devnet/src/main.rs
+++ b/devnet/src/main.rs
@@ -25,6 +25,8 @@ enum Commands {
     Unstake { account: String, amount: u64 },
     /// Slash staked tokens to the treasury
     Slash { account: String, amount: u64 },
+    /// Burn tokens from an account
+    Burn { account: String, amount: u64 },
     /// Show balances
     Balance { account: String },
     /// Show reputation score
@@ -93,6 +95,11 @@ fn main() -> Result<(), DevnetError> {
                 }
                 Commands::Slash { account, amount } => {
                     if let Err(e) = slash(&mut ledger, &account, amount) {
+                        println!("{e}");
+                    }
+                }
+                Commands::Burn { account, amount } => {
+                    if let Err(e) = burn(&mut ledger, &account, amount) {
                         println!("{e}");
                     }
                 }

--- a/devnet/tests/basic.rs
+++ b/devnet/tests/basic.rs
@@ -45,3 +45,13 @@ fn slash_and_reputation_flow() -> Result<(), runtime::token::LedgerError> {
     assert_eq!(ledger.balance(TREASURY), 25);
     Ok(())
 }
+
+#[test]
+fn burn_flow() -> Result<(), runtime::token::LedgerError> {
+    let mut ledger = TokenLedger::new();
+    mint(&mut ledger, "alice", 60);
+    burn(&mut ledger, "alice", 20)?;
+    assert_eq!(ledger.balance("alice"), 40);
+    assert!(burn(&mut ledger, "alice", 50).is_err());
+    Ok(())
+}

--- a/runtime/src/token.rs
+++ b/runtime/src/token.rs
@@ -52,6 +52,16 @@ impl TokenLedger {
         Ok(())
     }
 
+    /// Permanently remove tokens from an account, reducing total supply.
+    pub fn burn(&mut self, account: &str, amount: u64) -> Result<(), LedgerError> {
+        let bal = self.balances.entry(account.to_string()).or_default();
+        if *bal < amount {
+            return Err(LedgerError::InsufficientBalance);
+        }
+        *bal -= amount;
+        Ok(())
+    }
+
     /// Stake tokens from the caller's balance.
     pub fn stake(&mut self, account: &str, amount: u64) -> Result<(), LedgerError> {
         let bal = self.balances.entry(account.to_string()).or_default();

--- a/runtime/tests/token.rs
+++ b/runtime/tests/token.rs
@@ -48,3 +48,13 @@ fn slashing_and_reputation() -> Result<(), LedgerError> {
     assert_eq!(ledger.reputation("offender"), 2);
     Ok(())
 }
+
+#[test]
+fn burn_tokens() -> Result<(), LedgerError> {
+    let mut ledger = TokenLedger::new();
+    ledger.mint("alice", 50);
+    ledger.burn("alice", 20)?;
+    assert_eq!(ledger.balance("alice"), 30);
+    assert_eq!(ledger.burn("alice", 40).unwrap_err(), LedgerError::InsufficientBalance);
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- add token `burn` method in runtime ledger
- expose burn helper in devnet library and CLI
- add tests for new feature
- document Milestone 5 tasks in implementation plan

## Testing
- `cargo clippy --manifest-path runtime/Cargo.toml -- -D warnings`
- `cargo clippy --manifest-path devnet/Cargo.toml -- -D warnings`
- `cargo clippy --manifest-path jobmanager/Cargo.toml -- -D warnings`
- `cargo clippy --manifest-path keygen/Cargo.toml -- -D warnings`
- `cargo clippy --manifest-path p2p/Cargo.toml -- -D warnings`
- `cargo clippy --manifest-path dashboard/Cargo.toml -- -D warnings`
- `cargo test --manifest-path runtime/Cargo.toml`
- `cargo test --manifest-path devnet/Cargo.toml`
- `cargo test --manifest-path jobmanager/Cargo.toml`
- `cargo test --manifest-path keygen/Cargo.toml`
- `cargo test --manifest-path p2p/Cargo.toml`
- `cargo test --manifest-path dashboard/Cargo.toml`


------
https://chatgpt.com/codex/tasks/task_e_684d20a141dc832fb3b818d3ea14b8a1