### PR TITLE
Add concurrent job stress test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@
 /p2p/target
 /p2p/Cargo.lock
 /keygen/target
+/dashboard/target
+/dashboard/Cargo.lock

--- a/runtime/tests/stress.rs
+++ b/runtime/tests/stress.rs
@@ -1,0 +1,43 @@
+use std::sync::{Arc, Mutex};
+use std::thread;
+
+use runtime::job_manager::{JobManager, JobManagerError};
+use runtime::token::TokenLedger;
+
+#[test]
+fn concurrent_job_flow() -> Result<(), JobManagerError> {
+    const THREADS: usize = 4;
+    const JOBS_PER_THREAD: usize = 25;
+
+    let mut ledger = TokenLedger::new();
+    for i in 0..THREADS {
+        ledger.mint(&format!("user{i}"), 1_000);
+    }
+    let manager = Arc::new(Mutex::new(JobManager::new(ledger)));
+
+    let mut handles = Vec::new();
+    for i in 0..THREADS {
+        let jm = Arc::clone(&manager);
+        handles.push(thread::spawn(move || {
+            for j in 0..JOBS_PER_THREAD {
+                let poster = format!("user{i}");
+                let id = {
+                    let mut jm = jm.lock().unwrap();
+                    jm.post_job(&poster, format!("job {i}-{j}"), 1).unwrap().id
+                };
+                let mut jm = jm.lock().unwrap();
+                jm.assign_job(id, &poster).unwrap();
+                jm.complete_job(id).unwrap();
+            }
+        }));
+    }
+
+    for handle in handles {
+        handle.join().unwrap();
+    }
+
+    let jm = manager.lock().unwrap();
+    assert_eq!(jm.jobs().len(), THREADS * JOBS_PER_THREAD);
+    assert!(jm.jobs().iter().all(|j| j.completed));
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- cover Milestone 5 by stress testing job handling with multiple threads
- ignore dashboard build artifacts

## Testing
- `cargo clippy --manifest-path runtime/Cargo.toml --tests -- -D warnings`
- `cargo test --manifest-path runtime/Cargo.toml`
- `cargo test --manifest-path jobmanager/Cargo.toml`
- `cargo test --manifest-path devnet/Cargo.toml`
- `cargo test --manifest-path keygen/Cargo.toml`
- `cargo test --manifest-path p2p/Cargo.toml`
- `cargo test --manifest-path dashboard/Cargo.toml`


------
https://chatgpt.com/codex/tasks/task_e_684d2a3190f4832fbf455eff1f5e8f4f