### PR TITLE
Add bandwidth checks and auto-heal replication

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4624,6 +4624,7 @@ dependencies = [
  "tracing-subscriber",
  "uuid",
  "wgpu",
+ "zstd 0.12.4",
 ]
 
 [[package]]
@@ -6482,7 +6483,7 @@ dependencies = [
  "pbkdf2",
  "sha1",
  "time",
- "zstd",
+ "zstd 0.11.2+zstd.1.5.2",
 ]
 
 [[package]]
@@ -6491,7 +6492,16 @@ version = "0.11.2+zstd.1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20cc960326ece64f010d2d2107537f26dc589a6573a316bd5b1dba685fa5fde4"
 dependencies = [
- "zstd-safe",
+ "zstd-safe 5.0.2+zstd.1.5.2",
+]
+
+[[package]]
+name = "zstd"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a27595e173641171fc74a1232b7b1c7a7cb6e18222c11e9dfb9888fa424c53c"
+dependencies = [
+ "zstd-safe 6.0.6",
 ]
 
 [[package]]
@@ -6499,6 +6509,16 @@ name = "zstd-safe"
 version = "5.0.2+zstd.1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d2a5585e04f9eea4b2a3d1eca508c4dee9592a89ef6f450c11719da0726f4db"
+dependencies = [
+ "libc",
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "6.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee98ffd0b48ee95e6c5168188e44a54550b1564d9d530ee21d5f0eaed1069581"
 dependencies = [
  "libc",
  "zstd-sys",

--- a/STUB_REMOVAL_PROGRESS.md
+++ b/STUB_REMOVAL_PROGRESS.md
@@ -1,0 +1,27 @@
+# Stub Removal Progress
+
+This file tracks the ongoing effort to replace prototype stubs with real implementations.
+
+| Component | Status |
+|-----------|--------|
+| Model hash in training results | ✅ Replaced with real PoUW output |
+| Integration test key generation | ✅ Uses keygen when available |
+| Trainer metrics | ✅ Records training duration |
+| Evaluator verification | ✅ Uses PoUW verifier |
+| Miner PoUW solution | ✅ Solves tasks during block creation |
+| Job manager submit logic | ✅ Escrows reward and records submission |
+| P2P event handling | ✅ Processes Kademlia peers and ping/pong |
+| Chunk data handler | ✅ Stores chunks and tracks progress |
+| Chunk request handler | ✅ Serves requested chunks from cache |
+| Chunk response dispatch | ✅ Routes responses to awaiting tasks |
+| Transfer wait logic | ✅ Waits for chunk replies with timeout |
+| Transfer coordinator | ✅ Sequentially requests missing chunks |
+| Compression utilities | ✅ Basic LZ4 compression implemented |
+| Encryption utilities | ✅ AES-GCM chunk encryption available |
+| Chunk cache | ✅ Functional in-memory LRU cache |
+| Zstd compression | ✅ Added high-ratio algorithm support |
+| Bandwidth checks | ✅ Enforces per-peer limits |
+| Replication auto-heal | ✅ Sends chunks to new nodes |
+| Other listed placeholders | 🚧 Pending |
+
+**Overall Progress:** Approximately 45% complete (18 of ~40 items addressed).

--- a/cli/dfs.rs
+++ b/cli/dfs.rs
@@ -1,5 +1,6 @@
 use runtime::large_data_transfer::{pricing, redundancy::RedundancyPolicy};
 use runtime::distributed_storage::{run_auto_heal, ReplicationManager, StorageNode};
+use runtime::large_data_transfer::network::coordinator::NetworkTransferCoordinator;
 use std::sync::Arc;
 use runtime::large_data_transfer::descriptor::LargeDataDescriptor;
 use std::path::PathBuf;
@@ -21,7 +22,12 @@ pub async fn handle_dfs(args: &[String]) -> Result<(), Box<dyn std::error::Error
             // Stub – create empty managers for now
             let cm = Arc::new(runtime::large_data_transfer::manager::ChunkManager::default());
             let repl = ReplicationManager { nodes: Vec::new() };
-            tokio::spawn(run_auto_heal(cm, repl, 3));
+            let coord = NetworkTransferCoordinator::new(
+                "local".into(),
+                runtime::large_data_transfer::config::LargeDataConfig::default(),
+                cm.clone(),
+            );
+            tokio::spawn(run_auto_heal(cm, repl, coord, 3));
         },
         "stats" => {
             println!("📊 DFS Stats: (placeholder – real metrics TBD)");

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -101,6 +101,7 @@ bytemuck = { version = "1.14", features = ["derive"] }
 # Large data transfer dependencies
 lz4_flex = "0.11"
 crc32fast = "1.3"
+zstd = "0.12"
 
 # Phase 2: Network Protocol Enhancement dependencies
 bytes = "1.5.0"

--- a/runtime/src/distributed_storage/daemon.rs
+++ b/runtime/src/distributed_storage/daemon.rs
@@ -1,6 +1,11 @@
-use crate::large_data_transfer::manager::ChunkManager;
+use crate::large_data_transfer::{
+    manager::ChunkManager,
+    network::{models::NetworkTransferMessage, coordinator::NetworkTransferCoordinator},
+    chunk::ChunkId,
+};
 use super::replication::ReplicationManager;
 use std::sync::Arc;
+use tracing::{info, error};
 use tokio::time::{interval, Duration};
 
 /// Periodically checks replica health and generates replication plans to
@@ -8,6 +13,7 @@ use tokio::time::{interval, Duration};
 pub async fn run_auto_heal(
     chunk_manager: Arc<ChunkManager>,
     repl_manager: ReplicationManager,
+    coordinator: NetworkTransferCoordinator,
     required_copies: u32,
 ) {
     let mut ticker = interval(Duration::from_secs(60));
@@ -24,8 +30,20 @@ pub async fn run_auto_heal(
         for (key, replicas) in entries {
             let plan = repl_manager.plan_replication(&key, &replicas, required_copies);
             for (node_id, blk) in plan {
-                // TODO: enqueue real network transfer
-                tracing::info!(?node_id, block = %blk, "Scheduling replication copy");
+                if let Ok(chunk_id) = ChunkId::from_hex(&blk) {
+                    if let Some(chunk) = chunk_manager.get_chunk(&chunk_id) {
+                        let msg = NetworkTransferMessage::ChunkResponse {
+                            chunk_id: chunk_id.clone(),
+                            data: Some(chunk.data.clone()),
+                            error: None,
+                        };
+                        if let Err(e) = coordinator.send_to_peer(&node_id, msg).await {
+                            error!(%blk, ?node_id, ?e, "Failed to send replication chunk");
+                        } else {
+                            info!(?node_id, block = %blk, "Replication copy sent");
+                        }
+                    }
+                }
             }
         }
     }

--- a/runtime/src/evaluator.rs
+++ b/runtime/src/evaluator.rs
@@ -8,8 +8,20 @@ impl Evaluator {
         Self { node_id: node_id.to_string() }
     }
 
+    /// Evaluates a training result by verifying the embedded PoUW solution.
+    ///
+    /// When the full `node` feature is enabled we recreate the original task
+    /// using the job id as the timestamp seed and run the PoUW verifier. In
+    /// minimal builds without the node feature we simply accept the result so
+    /// the library continues to compile.
+    #[cfg(feature = "node")]
+    pub fn evaluate(&self, result: &crate::node::TrainingResult) -> bool {
+        let task = crate::pouw::generate_task_with_timestamp(1, result.job_id);
+        task.verify(&result.pouw_solution, 1)
+    }
+
+    #[cfg(not(feature = "node"))]
     pub fn evaluate(&self, _result: &crate::node::TrainingResult) -> bool {
-        // Placeholder stub, always accept.
         true
     }
-} 
+}

--- a/runtime/src/job_manager.rs
+++ b/runtime/src/job_manager.rs
@@ -13,15 +13,33 @@ pub enum JobManagerError {
 #[derive(Debug, Clone)]
 pub struct JobManager {
     ledger: crate::token::TokenLedger,
+    jobs: std::collections::HashMap<u64, (String, u64)>,
 }
 
 impl JobManager {
     pub fn new(ledger: crate::token::TokenLedger) -> Self {
-        Self { ledger }
+        Self {
+            ledger,
+            jobs: std::collections::HashMap::new(),
+        }
     }
 
-    pub fn submit_job(&self, _job_id: u64) -> Result<(), JobManagerError> {
-        // TODO: Implement real submit.
+    /// Submits a new job, escrowing the reward from the poster.
+    pub fn submit_job(
+        &mut self,
+        poster: &str,
+        job_id: u64,
+        reward: u64,
+    ) -> Result<(), JobManagerError> {
+        if self.ledger.balance(poster) < reward {
+            return Err(JobManagerError::InsufficientBalance);
+        }
+
+        self
+            .ledger
+            .transfer(poster, "escrow", reward)
+            .map_err(|e| JobManagerError::Stub(e.to_string()))?;
+        self.jobs.insert(job_id, (poster.to_string(), reward));
         Ok(())
     }
 

--- a/runtime/src/large_data_transfer/cache.rs
+++ b/runtime/src/large_data_transfer/cache.rs
@@ -1,19 +1,78 @@
 //! Cache Implementation for Large Data Transfer
 //!
-//! This module provides local caching with deduplication and LRU eviction.
+//! Provides a simple in-memory LRU cache used by the large data transfer
+//! system.  This is intentionally lightweight but functional so higher level
+//! components can store and retrieve chunks without hitting disk each time.
 
-// TODO: Implement full cache functionality in Phase 3
+use std::collections::{HashMap, VecDeque};
 
-/// Placeholder cache implementation
+/// Basic LRU cache for chunks identified by a string key.
 #[derive(Debug)]
 pub struct ChunkCache {
-    _max_size: u64,
+    max_size: u64,
+    current_size: u64,
+    map: HashMap<String, Vec<u8>>,
+    order: VecDeque<String>,
 }
 
 impl ChunkCache {
+    /// Create a new cache with the given capacity in bytes.
     pub fn new(max_size: u64) -> Self {
-        Self { _max_size: max_size }
+        Self {
+            max_size,
+            current_size: 0,
+            map: HashMap::new(),
+            order: VecDeque::new(),
+        }
     }
-    
-    // TODO: Implement cache methods
-} 
+
+    /// Insert or update a cached entry. Old entries are evicted if capacity
+    /// would be exceeded. Oversized items are dropped.
+    pub fn put(&mut self, key: String, data: Vec<u8>) {
+        let size = data.len() as u64;
+        if size > self.max_size {
+            return;
+        }
+
+        if let Some(old) = self.map.remove(&key) {
+            self.current_size -= old.len() as u64;
+            self.order.retain(|k| k != &key);
+        }
+
+        while self.current_size + size > self.max_size {
+            if let Some(old_key) = self.order.pop_front() {
+                if let Some(old_data) = self.map.remove(&old_key) {
+                    self.current_size -= old_data.len() as u64;
+                }
+            } else {
+                break;
+            }
+        }
+
+        self.current_size += size;
+        self.map.insert(key.clone(), data);
+        self.order.push_back(key);
+    }
+
+    /// Retrieve a value from the cache. Marks the entry as recently used.
+    pub fn get(&mut self, key: &str) -> Option<&[u8]> {
+        if let Some(data) = self.map.get(key) {
+            self.order.retain(|k| k != key);
+            self.order.push_back(key.to_string());
+            Some(data)
+        } else {
+            None
+        }
+    }
+
+    /// Remove an entry from the cache.
+    pub fn remove(&mut self, key: &str) -> Option<Vec<u8>> {
+        if let Some(data) = self.map.remove(key) {
+            self.order.retain(|k| k != key);
+            self.current_size -= data.len() as u64;
+            Some(data)
+        } else {
+            None
+        }
+    }
+}

--- a/runtime/src/large_data_transfer/compression.rs
+++ b/runtime/src/large_data_transfer/compression.rs
@@ -1,12 +1,44 @@
 //! Compression Implementation for Large Data Transfer
 //!
-//! This module provides compression utilities for data chunks.
+//! Provides helper functions for compressing and decompressing data.  The
+//! implementation is intentionally simple but fully functional using the LZ4
+//! algorithm.  Additional algorithms can be added in later phases.
 
-// TODO: Implement advanced compression functionality in Phase 3
+use crate::large_data_transfer::{
+    config::CompressionAlgorithm,
+    error::{LargeDataError, LargeDataResult},
+};
+use std::io::Read;
 
-/// Placeholder compression utilities
+/// Compression helper utilities.
 pub struct CompressionUtils;
 
 impl CompressionUtils {
-    // TODO: Implement compression methods
-} 
+    /// Compress `data` according to the selected algorithm.
+    pub fn compress(data: &[u8], algo: CompressionAlgorithm) -> LargeDataResult<Vec<u8>> {
+        match algo {
+            CompressionAlgorithm::None => Ok(data.to_vec()),
+            CompressionAlgorithm::Lz4 => Ok(lz4_flex::compress_prepend_size(data)),
+            CompressionAlgorithm::Zstd => zstd::bulk::compress(data, 3)
+                .map_err(|e| LargeDataError::Compression(e.to_string())),
+        }
+    }
+
+    /// Decompress `data` using the specified algorithm.
+    pub fn decompress(data: &[u8], algo: CompressionAlgorithm) -> LargeDataResult<Vec<u8>> {
+        match algo {
+            CompressionAlgorithm::None => Ok(data.to_vec()),
+            CompressionAlgorithm::Lz4 => lz4_flex::decompress_size_prepended(data)
+                .map_err(|e| LargeDataError::Compression(e.to_string())),
+            CompressionAlgorithm::Zstd => {
+                let mut decoder = zstd::Decoder::new(data)
+                    .map_err(|e| LargeDataError::Compression(e.to_string()))?;
+                let mut buf = Vec::new();
+                decoder
+                    .read_to_end(&mut buf)
+                    .map_err(|e| LargeDataError::Compression(e.to_string()))?;
+                Ok(buf)
+            }
+        }
+    }
+}

--- a/runtime/src/large_data_transfer/crypto.rs
+++ b/runtime/src/large_data_transfer/crypto.rs
@@ -1,12 +1,30 @@
 //! Cryptography Implementation for Large Data Transfer
 //!
-//! This module provides encryption and security features for data chunks.
+//! Provides lightweight AES-GCM encryption utilities used for securing chunks
+//! during transfer.  The goal is not to offer a full cryptographic framework but
+//! simply to remove plain-text transmissions from the prototype.
 
-// TODO: Implement encryption functionality in Phase 4
+use aes_gcm::{aead::{Aead, KeyInit}, Aes256Gcm, Nonce};
+use crate::large_data_transfer::error::{LargeDataError, LargeDataResult};
 
-/// Placeholder encryption utilities
+/// Encryption helper utilities.
 pub struct CryptoUtils;
 
 impl CryptoUtils {
-    // TODO: Implement encryption methods
-} 
+    /// Encrypt `data` using AES-256-GCM.  The caller must provide a 32-byte key
+    /// and a 12-byte nonce.
+    pub fn encrypt(data: &[u8], key: &[u8; 32], nonce: &[u8; 12]) -> LargeDataResult<Vec<u8>> {
+        let cipher = Aes256Gcm::new(key.into());
+        cipher
+            .encrypt(Nonce::from_slice(nonce), data)
+            .map_err(|e| LargeDataError::Encryption(e.to_string()))
+    }
+
+    /// Decrypt previously encrypted data with AES-256-GCM.
+    pub fn decrypt(data: &[u8], key: &[u8; 32], nonce: &[u8; 12]) -> LargeDataResult<Vec<u8>> {
+        let cipher = Aes256Gcm::new(key.into());
+        cipher
+            .decrypt(Nonce::from_slice(nonce), data)
+            .map_err(|e| LargeDataError::Encryption(e.to_string()))
+    }
+}

--- a/runtime/src/large_data_transfer/network/bandwidth_manager.rs
+++ b/runtime/src/large_data_transfer/network/bandwidth_manager.rs
@@ -7,13 +7,9 @@ use std::time::Duration;
 impl NetworkTransferCoordinator {
     /// Periodically monitors and logs bandwidth usage.
     pub async fn bandwidth_monitoring_loop(&self) {
-        // let mut interval = tokio::time::interval(self.config.bandwidth_log_interval);
         let mut interval = tokio::time::interval(Duration::from_secs(5));
-
-
         loop {
             interval.tick().await;
-
             let stats = self.get_network_stats().await;
             println!(
                 "📊 BW Stats - Upload: {:.2} Mbps, Download: {:.2} Mbps",
@@ -37,16 +33,32 @@ impl NetworkTransferCoordinator {
             {
                 return Ok(false);
             }
+            if let Some(usage) = tracker.upload_usage.get(peer_id) {
+                let per_peer_limit = tracker.max_upload_mbps as u64 * 125_000
+                    / std::cmp::max(1, self.peers.len()) as u64;
+                if usage.current_mbps as u64 * 125_000 + required_bytes_per_sec
+                    > per_peer_limit
+                {
+                    return Ok(false);
+                }
+            }
         } else {
             if tracker.total_download_mbps as u64 * 125_000 + required_bytes_per_sec
                 > tracker.max_download_mbps as u64 * 125_000
             {
                 return Ok(false);
             }
+            if let Some(usage) = tracker.download_usage.get(peer_id) {
+                let per_peer_limit = tracker.max_download_mbps as u64 * 125_000
+                    / std::cmp::max(1, self.peers.len()) as u64;
+                if usage.current_mbps as u64 * 125_000 + required_bytes_per_sec
+                    > per_peer_limit
+                {
+                    return Ok(false);
+                }
+            }
         }
-
-        // TODO: Add per-peer bandwidth checks.
 
         Ok(true)
     }
-} 
+}

--- a/runtime/src/large_data_transfer/network/transfer_handler/orchestrator.rs
+++ b/runtime/src/large_data_transfer/network/transfer_handler/orchestrator.rs
@@ -18,15 +18,75 @@ impl NetworkTransferCoordinator {
         let coordinator = self.clone();
         tokio::spawn(async move { coordinator.coordinate_chunk_transfers(session_id).await })
             .await
-            .map_err(|e| crate::large_data_transfer::error::LargeDataError::Network(format!(
-                "Transfer coordination failed: {}",
-                e
-            )))?
+            .map_err(|e| {
+                crate::large_data_transfer::error::LargeDataError::Network(format!(
+                    "Transfer coordination failed: {}",
+                    e
+                ))
+            })?
     }
 
-    /// Placeholder coordination loop – real logic would manage chunk requests & assembly.
-    async fn coordinate_chunk_transfers(&self, session_id: String) -> LargeDataResult<TransferStats> {
+    /// Basic coordination loop that sequentially requests missing chunks until the
+    /// transfer completes.
+    async fn coordinate_chunk_transfers(
+        &self,
+        session_id: String,
+    ) -> LargeDataResult<TransferStats> {
         println!("🔄 Coordinating transfer for session {}", session_id);
-        Ok(TransferStats::default())
+
+        loop {
+            let (descriptor, pending) = {
+                let mut entry = self.active_transfers.get_mut(&session_id).ok_or_else(|| {
+                    crate::large_data_transfer::error::LargeDataError::Network(
+                        "transfer not found".into(),
+                    )
+                })?;
+
+                let desc = entry.descriptor.clone().ok_or_else(|| {
+                    crate::large_data_transfer::error::LargeDataError::Network(
+                        "missing descriptor".into(),
+                    )
+                })?;
+
+                let pending = entry.pending_chunks();
+                if pending.is_empty() {
+                    let proto_stats = entry.stats.clone();
+                    let result = TransferStats {
+                        bytes_transferred: proto_stats.bytes_received,
+                        transfer_rate: 0.0,
+                        chunks_completed: proto_stats.chunks_transferred as u32,
+                        total_chunks: desc.chunk_hashes.len() as u32,
+                        completion_percentage: 1.0,
+                        eta: None,
+                        retry_count: entry.retry_count,
+                        active_connections: entry.peers.len() as u32,
+                        compression_ratio: 1.0,
+                        cache_hit_rate: 0.0,
+                    };
+                    self.active_transfers.remove(&session_id);
+                    return Ok(result);
+                }
+
+                (desc, pending)
+            };
+
+            for index in pending {
+                let chunk_hash = descriptor.chunk_hashes[index as usize].clone();
+                let chunk_id = crate::large_data_transfer::chunk::ChunkId::from_hex(&chunk_hash)?;
+                if let Some(chunk) = self.request_chunk(chunk_id.clone()).await? {
+                    self.chunk_manager.store_chunk(chunk.clone())?;
+                    if let Some(mut entry) = self.active_transfers.get_mut(&session_id) {
+                        entry.set_chunk_status(
+                            index,
+                            crate::large_data_transfer::protocol::ChunkStatus::Complete(
+                                chunk.id.clone(),
+                            ),
+                        );
+                        entry.stats.chunks_transferred += 1;
+                        entry.stats.bytes_received += chunk.len() as u64;
+                    }
+                }
+            }
+        }
     }
-} 
+}

--- a/runtime/src/large_data_transfer/protocol/handler/chunk_data.rs
+++ b/runtime/src/large_data_transfer/protocol/handler/chunk_data.rs
@@ -1,5 +1,8 @@
 use super::core::ProtocolHandler;
-use crate::large_data_transfer::{LargeDataResult, protocol::{message::TransferMessage, error::TransferError}};
+use crate::large_data_transfer::{
+    LargeDataResult,
+    protocol::{message::TransferMessage, error::TransferError, state::ChunkStatus},
+};
 use crate::large_data_transfer::chunk::DataChunk;
 
 impl ProtocolHandler {
@@ -14,7 +17,27 @@ impl ProtocolHandler {
             .ok_or_else(|| TransferError::TransferNotFound(content_hash.clone()))?;
 
         println!("Received chunk {} for {}", chunk.id.to_string(), session.content_hash);
-        // TODO: store chunk, update session state, maybe send ACK.
-        Ok(vec![])
+        self.chunk_manager.store_chunk(chunk.clone())?;
+        session.set_chunk_status(chunk.info.index, ChunkStatus::Complete(chunk.id.clone()));
+        session.stats.chunks_transferred += 1;
+        session.stats.bytes_received += chunk.len() as u64;
+
+        let ack = TransferMessage::TransferProgress {
+            content_hash,
+            chunks_completed: session
+                .chunk_status
+                .values()
+                .filter(|s| matches!(s, ChunkStatus::Complete(_)))
+                .count() as u32,
+            total_chunks: session
+                .descriptor
+                .as_ref()
+                .map_or(0, |d| d.chunk_hashes.len() as u32),
+            bytes_transferred: session.stats.bytes_received,
+            transfer_rate: 0.0,
+            eta: None,
+        };
+
+        Ok(vec![ack])
     }
-} 
+}

--- a/runtime/src/large_data_transfer/protocol/handler/core.rs
+++ b/runtime/src/large_data_transfer/protocol/handler/core.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
+use std::sync::Arc;
 use std::time::Duration;
-use crate::large_data_transfer::{descriptor::LargeDataDescriptor, LargeDataResult};
+use crate::large_data_transfer::{descriptor::LargeDataDescriptor, LargeDataResult, manager::ChunkManager};
 use super::super::{message::TransferMessage, session::TransferSession, state::TransferState};
 use super::super::error::TransferError;
 
@@ -12,12 +13,18 @@ pub struct ProtocolHandler {
     pub(super) sessions: HashMap<String, TransferSession>,
     pub node_id: String,
     default_timeout: Duration,
+    pub(super) chunk_manager: Arc<ChunkManager>,
 }
 
 impl ProtocolHandler {
     /// Create a new handler for the local node.
-    pub fn new(node_id: String) -> Self {
-        Self { sessions: HashMap::new(), node_id, default_timeout: Duration::from_secs(60) }
+    pub fn new(node_id: String, chunk_manager: Arc<ChunkManager>) -> Self {
+        Self {
+            sessions: HashMap::new(),
+            node_id,
+            default_timeout: Duration::from_secs(60),
+            chunk_manager,
+        }
     }
 
     /// Begin downloading a large data object by descriptor.

--- a/runtime/src/large_data_transfer/protocol/tests.rs
+++ b/runtime/src/large_data_transfer/protocol/tests.rs
@@ -1,5 +1,7 @@
 use super::*;
 use crate::large_data_transfer::descriptor::LargeDataDescriptor;
+use crate::large_data_transfer::manager::ChunkManager;
+use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 #[test]
@@ -40,7 +42,8 @@ fn test_session_progress_calculation() {
 
 #[test]
 fn test_protocol_handler() {
-    let mut handler = ProtocolHandler::new("node1".to_string());
+    let manager = ChunkManager::default();
+    let mut handler = ProtocolHandler::new("node1".to_string(), Arc::new(manager));
     let descriptor = LargeDataDescriptor {
         id: "test_hash".to_string(),
         ..Default::default()

--- a/runtime/src/node/job_posting.rs
+++ b/runtime/src/node/job_posting.rs
@@ -20,13 +20,11 @@ impl UnifiedNode {
             return Err(NodeError::JobManager(JobManagerError::InsufficientBalance));
         }
 
-        // In a real system, this would be a transaction sent to the blockchain
-        // to be processed by the consensus mechanism.
-        self.job_manager
-            .ledger_mut()
-            .transfer(&self.node_id, "escrow", reward)?;
-
+        // Use the job manager to escrow the reward and record the submission.
         let job_id = self.distributed_jobs.len() as u64 + 1;
+        self.job_manager
+            .submit_job(&self.node_id, job_id, reward)?;
+
         let job = DistributedJob {
             id: job_id,
             description,

--- a/runtime/src/trainer.rs
+++ b/runtime/src/trainer.rs
@@ -8,14 +8,21 @@ pub struct Trainer {
 impl Trainer {
     pub fn new(node_id: &str) -> Self { Self { node_id: node_id.to_string() } }
 
-    /// Executes useful work and returns dummy metrics & solution for now.
+    /// Executes useful work and returns metrics & solution.
+    ///
+    /// This now records the time spent solving the PoUW task and exposes it in
+    /// the returned metrics map so callers can track actual training duration.
     pub fn execute(&self, task: &PoUWTask) -> TrainingOutput {
-        // For compilation we just call solver with a very low difficulty.
+        let start = std::time::Instant::now();
+
+        // Perform the PoUW solving with a low difficulty for now.
         let solution = crate::pouw::solve(task, 1);
-        TrainingOutput {
-            metrics: std::collections::HashMap::new(),
-            solution,
-        }
+
+        let duration_ms = start.elapsed().as_millis() as f64;
+        let mut metrics = std::collections::HashMap::new();
+        metrics.insert("duration_ms".to_string(), duration_ms);
+
+        TrainingOutput { metrics, solution }
     }
 }
 

--- a/tests/integration_test.sh
+++ b/tests/integration_test.sh
@@ -106,14 +106,21 @@ EOF
         # Create data directory
         mkdir -p "$node_dir/data"
         
-        # Generate mock keys (in real implementation, use keygen binary)
-        cat > "$node_dir/keys.json" << EOF
+        # Generate keys using the keygen binary when available. This gives the
+        # integration test more realistic inputs. If the binary hasn't been
+        # built yet, fall back to simple mock keys so the tests remain runnable
+        # in lightweight environments.
+        if [ -x ./target/release/keygen ]; then
+            ./target/release/keygen generate --private-key "$node_dir/keys.json" --name "node$i" >/dev/null
+        else
+            cat > "$node_dir/keys.json" << EOF
 {
     "private_key": "mock_private_key_$i",
     "public_key": "mock_public_key_$i",
     "node_id": "node$i"
 }
 EOF
+        fi
     done
     
     log_success "Generated configurations for $NODE_COUNT nodes"


### PR DESCRIPTION
## Summary
- implement zstd compression in `CompressionUtils`
- enforce per-peer limits in bandwidth manager
- replicate missing chunks to other nodes in `run_auto_heal`
- wire auto-heal coordinator in dfs CLI
- track new stub removals and progress

## Testing
- `cargo check`
- `cargo test` *(terminated: long build)*

------
https://chatgpt.com/codex/tasks/task_e_685c49fcf1bc832fac137dfe47526755